### PR TITLE
tls: add nil check for rawInput before freeing memory

### DIFF
--- a/std/crypto/tls/conn.go
+++ b/std/crypto/tls/conn.go
@@ -826,7 +826,7 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 	}
 
 	defer func() {
-		if len(*c.rawInput) == c.rawInputOff {
+		if c.rawInput != nil && len(*c.rawInput) == c.rawInputOff {
 			c.allocator.Free(c.rawInput)
 			c.rawInput = nil
 			c.rawInputOff = 0


### PR DESCRIPTION
fix nil deref in readRecordOrCCS defer after recursive retry